### PR TITLE
Force LF line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+*      text=auto
+
+*.js   text eol=lf
+*.c    text eol=lf


### PR DESCRIPTION
Closes #62 (I hope). This forces Git to use LF line endings.

When cloning the repo via Git, #62 does not occur, as Git is smart enough to use the correct line endings. I suppose the npm packages are packed by a Windows user, and npm doesn't seem to convert CRLF to LF line endings. This should force LF line endings, but the packager should probably also use something like [dos2unix](https://waterlan.home.xs4all.nl/dos2unix/man1/dos2unix.htm) or change their editor's settings so that it truly stays LF (don't know how Windows handles this).