### PR TITLE
Fix multiple anonymous function declarations

### DIFF
--- a/compiler/native/lib/createAnon.js
+++ b/compiler/native/lib/createAnon.js
@@ -80,7 +80,7 @@ function createAnon(_code, _scope)
 
 						if(_match[1]) COMPILER.DECL.push(`var ${_match[2]};`);
 						if(_match[2]) _formated += _match[2] + " = ";
-						_formated += "NJS::VAR(NJS::Enum::Type::Function, new NJS::Type::function_t ([" + _catch + "](var __NJS_THIS, NJS::VAR* __NJS_VARARGS, int __NJS_VARLENGTH) -> NJS::VAR" + _fn + os.EOL + _return + "), __NJS_THIS);";
+						_formated += "NJS::VAR(NJS::Enum::Type::Function, new NJS::Type::function_t ([" + _catch + "](var __NJS_THIS, NJS::VAR* __NJS_VARARGS, int __NJS_VARLENGTH) -> NJS::VAR" + _fn + os.EOL + _return + "), __NJS_THIS)";
 						_code = [_code.slice(0, _index), ' ', _formated, _code.slice(_end + 1)].join('');		
 						break;
 					}


### PR DESCRIPTION
This change fix a bug when we declare multiple anonymous functions in a `VariableDeclaration`
Example before fix:
```js
var a = function () {
  console.log(1);
}, b = function () {
  console.log(2);
}, c = function () {
  console.log(3);
};

a();
b();
c();
```
Output:
```c
a = NJS::VAR(NJS::Enum::Type::Function, // stuff ...
return undefined;}), __NJS_THIS);,
// ------------------------------^ this comma is the bug
b = NJS::VAR(NJS::Enum::Type::Function, // stuff ...
return undefined;}), __NJS_THIS);,
// ------------------------------^ this comma is the bug
c = NJS::VAR(NJS::Enum::Type::Function, // stuff ...
return undefined;}), __NJS_THIS);;
// ------------------------------^ multiple semicolon, not a bug but ugly right? 😅🤣
```
Example output after fix:
```c
a = NJS::VAR(NJS::Enum::Type::Function, // stuff ...
return undefined;}), __NJS_THIS),
// -----------------------------^ just a comma
b = NJS::VAR(NJS::Enum::Type::Function, // stuff ...
return undefined;}), __NJS_THIS),
// -----------------------------^ just a comma
c = NJS::VAR(NJS::Enum::Type::Function, // stuff ...
return undefined;}), __NJS_THIS);
// ------------------------------^ just one semicolon 🎉
```